### PR TITLE
Fix typo

### DIFF
--- a/4.0/filling-in-the-layout.html
+++ b/4.0/filling-in-the-layout.html
@@ -1570,7 +1570,7 @@
 <div class="listing"><span class="header">リスト5.26</span> <span class="description">フッターパーシャルにリンクを追加する。</span><br /><span class="description"> <code>app/views/layouts/_footer.html.erb</code></span> </div>
 <div class="code"><div class="highlight"><pre><span class="nt">&lt;footer</span> <span class="na">class=</span><span class="s">&quot;footer&quot;</span><span class="nt">&gt;</span>
   <span class="nt">&lt;small&gt;</span>
-    <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">&quot;http://railstutorial.org/&quot;</span><span class="nt">&gt;</span>Rails Tutorial<span class="nt">&lt;/a&gt;</span>
+    <span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">&quot;http://railstutorial.jp/&quot;</span><span class="nt">&gt;</span>Rails Tutorial<span class="nt">&lt;/a&gt;</span>
     by Michael Hartl
   <span class="nt">&lt;/small&gt;</span>
   <span class="nt">&lt;nav&gt;</span>


### PR DESCRIPTION
<span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">&quot;http://railstutorial.org/&quot;</span><span class="nt">&gt;</span>Rails Tutorial<span class="nt">&lt;/a&gt;</span>
↓
<span class="nt">&lt;a</span> <span class="na">href=</span><span class="s">&quot;http://railstutorial.jp/&quot;</span><span class="nt">&gt;</span>Rails Tutorial<span class="nt">&lt;/a&gt;</span>
