### PR TITLE
rename to_false -> to_falsey

### DIFF
--- a/4.0/modeling-users.html
+++ b/4.0/modeling-users.html
@@ -1506,7 +1506,7 @@ add_password_digest_to_users password_digest:string
     <span class="n">let</span><span class="p">(</span><span class="ss">:user_for_invalid_password</span><span class="p">)</span> <span class="p">{</span> <span class="n">found_user</span><span class="o">.</span><span class="n">authenticate</span><span class="p">(</span><span class="s2">&quot;invalid&quot;</span><span class="p">)</span> <span class="p">}</span>
 
     <span class="n">it</span> <span class="p">{</span> <span class="n">should_not</span> <span class="n">eq</span> <span class="n">user_for_invalid_password</span> <span class="p">}</span>
-    <span class="n">specify</span> <span class="p">{</span> <span class="n">expect</span><span class="p">(</span><span class="n">user_for_invalid_password</span><span class="p">)</span><span class="o">.</span><span class="n">to</span> <span class="n">be_false</span> <span class="p">}</span>
+    <span class="n">specify</span> <span class="p">{</span> <span class="n">expect</span><span class="p">(</span><span class="n">user_for_invalid_password</span><span class="p">)</span><span class="o">.</span><span class="n">to</span> <span class="n">be_falsey</span> <span class="p">}</span>
   <span class="k">end</span>
 <span class="k">end</span>
 </pre></div>
@@ -1528,7 +1528,7 @@ add_password_digest_to_users password_digest:string
   <span class="n">let</span><span class="p">(</span><span class="ss">:user_for_invalid_password</span><span class="p">)</span> <span class="p">{</span> <span class="n">found_user</span><span class="o">.</span><span class="n">authenticate</span><span class="p">(</span><span class="s2">&quot;invalid&quot;</span><span class="p">)</span> <span class="p">}</span>
 
   <span class="n">it</span> <span class="p">{</span> <span class="n">should_not</span> <span class="n">eq</span> <span class="n">user_for_invalid_password</span> <span class="p">}</span>
-  <span class="n">specify</span> <span class="p">{</span> <span class="n">expect</span><span class="p">(</span><span class="n">user_for_invalid_password</span><span class="p">)</span><span class="o">.</span><span class="n">to</span> <span class="n">be_false</span> <span class="p">}</span>
+  <span class="n">specify</span> <span class="p">{</span> <span class="n">expect</span><span class="p">(</span><span class="n">user_for_invalid_password</span><span class="p">)</span><span class="o">.</span><span class="n">to</span> <span class="n">be_falsey</span> <span class="p">}</span>
 <span class="k">end</span>
 </pre></div>
 </div>
@@ -1600,7 +1600,7 @@ add_password_digest_to_users password_digest:string
       <span class="n">let</span><span class="p">(</span><span class="ss">:user_for_invalid_password</span><span class="p">)</span> <span class="p">{</span> <span class="n">found_user</span><span class="o">.</span><span class="n">authenticate</span><span class="p">(</span><span class="s2">&quot;invalid&quot;</span><span class="p">)</span> <span class="p">}</span>
 
       <span class="n">it</span> <span class="p">{</span> <span class="n">should_not</span> <span class="n">eq</span> <span class="n">user_for_invalid_password</span> <span class="p">}</span>
-      <span class="n">specify</span> <span class="p">{</span> <span class="n">expect</span><span class="p">(</span><span class="n">user_for_invalid_password</span><span class="p">)</span><span class="o">.</span><span class="n">to</span> <span class="n">be_false</span> <span class="p">}</span>
+      <span class="n">specify</span> <span class="p">{</span> <span class="n">expect</span><span class="p">(</span><span class="n">user_for_invalid_password</span><span class="p">)</span><span class="o">.</span><span class="n">to</span> <span class="n">be_falsey</span> <span class="p">}</span>
     <span class="k">end</span>
   <span class="k">end</span>
 <span class="k">end</span>


### PR DESCRIPTION
tutorialの翻訳ありがとうございます。実施最中ですが、下記、method名の変更があったようで、
`to_false`だとエラーになっていましたので、`to_falsey`に変更しました。

よろしくお願いいたします。

see https://github.com/rspec/rspec-expectations/issues/283
